### PR TITLE
feat: add Python bindings via PyO3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ Implements the `minimax::Game` trait. Uses a **linear biconnected component algo
 ### Interface Layers
 - **UHP Server** (`uhp_server.rs`): stdin/stdout protocol, compatible with MzingaViewer. Supports Mosquito, Ladybug, Pillbug expansions.
 - **CLI** (`cli.rs`): Interactive terminal play with Unicode board rendering.
-- **Python** (`python.rs`): PyO3 bindings exposing `GameState`, `PyMove`, `PyPiece` classes. Built with `maturin`.
+- **Python** (`python.rs`): PyO3 bindings exposing `GameState`, `PyMove`, `PyPiece` classes. Includes `encode_board()` for ML tensor output (84x32x32 numpy array). Built with `maturin`.
 - **WASM** (`wasm.rs`): Single `uhp(args) -> str` function wrapping a lazy-locked UHP server.
 
 ### Entry Point (main.rs)
@@ -63,11 +63,12 @@ CLI dispatcher with subcommands: `cli`, `uhp`, `play`, `perft`, `uhp-debug`. Key
 
 - `larger-grid` (default) — 32x32 hex grid
 - `smaller-grid` — 16x16 grid, more memory efficient but less accurate at edges
-- `python` — enables PyO3 bindings, changes crate type to cdylib+rlib
+- `python` — enables PyO3 + numpy bindings, changes crate type to cdylib+rlib. Use `cargo check --lib --features python` to verify (not `cargo build`, which fails at link time without a Python interpreter).
 
 ## Key Design Decisions
 
 - **Performance is the primary goal.** Flat arrays, packed structs, minimal allocations. Changes should not regress cache behavior or add unnecessary indirection.
 - **Zobrist hashing** for board state (lazy-initialized via `OnceLock`).
 - **Deterministic move ordering** in Python bindings (via `sort_key()`) for reproducible ML training.
-- Bug types are an enum with 8 variants: Queen, Ant, Spider, Beetle, Grasshopper, Mosquito, Ladybug, Pillbug.
+- **Canonical piece type ordering** (`bug_sort_ord`): Queen=0, Beetle=1, Grasshopper=2, Ant=3, Spider=4, Mosquito=5, Ladybug=6, Pillbug=7. This differs from the `Bug` enum discriminants and is used by both tensor encoding and move sorting.
+- Bug types are an enum with 8 variants: Queen, Grasshopper, Spider, Ant, Beetle, Mosquito, Ladybug, Pillbug (note: enum order differs from sort order above).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,73 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What is Nokamute
+
+Nokamute is a high-performance Hive board game engine in Rust (~4.6K LOC). It supports native CLI, UHP (Universal Hive Protocol) server, Python bindings (PyO3), and WebAssembly targets.
+
+## Build & Test Commands
+
+```bash
+# Build
+cargo build
+cargo build --release
+
+# Run tests (always run both feature sets)
+cargo test && cargo test --features=smaller-grid
+
+# UHP correctness suite (runs against itself)
+cargo run -- --strategy=random uhp-debug target/debug/nokamute --strategy=random
+
+# Lint & format
+cargo clippy --no-deps -- -D warnings
+cargo fmt -- --check
+
+# Benchmarks
+cargo build --benches
+
+# Python bindings (requires maturin)
+maturin develop --features python
+
+# WebAssembly
+rustup target add wasm32-unknown-unknown
+RUSTFLAGS='--cfg getrandom_backend="wasm_js"' wasm-pack test --firefox --headless
+
+# Optimized release build
+CARGO_PROFILE_RELEASE_LTO=true CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1 cargo build --release
+```
+
+## Architecture
+
+### Board Representation (board.rs — the core)
+The board is a **32x32 flat byte array hex grid** that wraps on all 3 axes like a torus. Each cell is a single `Node` byte with bit-packed fields: color (bit 7), bug type (bits 4-6), bug number (bits 2-3), stack height (bits 0-1). This design prioritizes cache locality and minimal allocation. An "underworld cache" handles stacks above height 3.
+
+### Move Generation
+Implements the `minimax::Game` trait. Uses a **linear biconnected component algorithm** to detect pinned pieces (pieces whose removal would disconnect the hive). This is the most performance-critical code path.
+
+### Search & Evaluation
+- Integrates with the external `minimax` crate (0.6.0) for alpha-beta with iterative deepening, parallel search, transposition tables
+- Strategy options: `iterative`, `mcts`, `mtdf`, `random` (via `--strategy` flag)
+- `BasicEvaluator` scores based on queen liberties, movable pieces, unplayed pieces; coefficients are acknowledged as rough ("made up") and marked for improvement
+
+### Interface Layers
+- **UHP Server** (`uhp_server.rs`): stdin/stdout protocol, compatible with MzingaViewer. Supports Mosquito, Ladybug, Pillbug expansions.
+- **CLI** (`cli.rs`): Interactive terminal play with Unicode board rendering.
+- **Python** (`python.rs`): PyO3 bindings exposing `GameState`, `PyMove`, `PyPiece` classes. Built with `maturin`.
+- **WASM** (`wasm.rs`): Single `uhp(args) -> str` function wrapping a lazy-locked UHP server.
+
+### Entry Point (main.rs)
+CLI dispatcher with subcommands: `cli`, `uhp`, `play`, `perft`, `uhp-debug`. Key flags: `--strategy`, `--table-mb` (transposition table size), `--threads`.
+
+## Cargo Features
+
+- `larger-grid` (default) — 32x32 hex grid
+- `smaller-grid` — 16x16 grid, more memory efficient but less accurate at edges
+- `python` — enables PyO3 bindings, changes crate type to cdylib+rlib
+
+## Key Design Decisions
+
+- **Performance is the primary goal.** Flat arrays, packed structs, minimal allocations. Changes should not regress cache behavior or add unnecessary indirection.
+- **Zobrist hashing** for board state (lazy-initialized via `OnceLock`).
+- **Deterministic move ordering** in Python bindings (via `sort_key()`) for reproducible ML training.
+- Bug types are an enum with 8 variants: Queen, Ant, Spider, Beetle, Grasshopper, Mosquito, Ladybug, Pillbug.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ license = "MIT"
 git-version = "0.3"
 minimax = "0.6.0"
 rand = "0.9"
+numpy = { version = "0.23", optional = true }
 pyo3 = { version = "0.23", features = ["extension-module"], optional = true }
 
 [target.'cfg(not(target_arch="wasm32"))'.dependencies]
@@ -32,7 +33,7 @@ smaller-grid = []
 # No-op for backwards compatibility.
 larger-grid = []
 # Python bindings via PyO3
-python = ["pyo3"]
+python = ["pyo3", "numpy"]
 
 [[bench]]
 name = "minimax"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ license = "MIT"
 git-version = "0.3"
 minimax = "0.6.0"
 rand = "0.9"
+pyo3 = { version = "0.23", features = ["extension-module"], optional = true }
 
 [target.'cfg(not(target_arch="wasm32"))'.dependencies]
 pico-args = "0.4"
@@ -30,11 +31,13 @@ wasm-bindgen-test = "0.3"
 smaller-grid = []
 # No-op for backwards compatibility.
 larger-grid = []
+# Python bindings via PyO3
+python = ["pyo3"]
 
 [[bench]]
 name = "minimax"
 harness = false
 
-# For wasm32 library builds.
+# cdylib needed for wasm32 and Python (PyO3) builds.
 [lib]
 crate-type=["cdylib", "rlib"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[build-system]
+requires = ["maturin>=1.0,<2.0"]
+build-backend = "maturin"
+
+[project]
+name = "nokamute"
+version = "0.1.0"
+description = "Python bindings for nokamute Hive AI engine"
+requires-python = ">=3.8"
+
+[tool.maturin]
+features = ["python"]

--- a/src/board.rs
+++ b/src/board.rs
@@ -97,6 +97,9 @@ impl UnderNode {
     pub fn hex(&self) -> Hex {
         self.hex
     }
+    pub fn height(&self) -> u8 {
+        self.height
+    }
 }
 
 #[derive(Clone)]

--- a/src/board.rs
+++ b/src/board.rs
@@ -108,7 +108,7 @@ pub struct Board {
     underworld: [UnderNode; 8],
     underworld_size: usize,
     pub remaining: [[u8; 8]; 2],
-    pub queens: [Hex; 2],
+    pub(crate) queens: [Hex; 2],
     pub occupied_hexes: [Vec<Hex>; 2],
 
     pub turn_num: u16,

--- a/src/board.rs
+++ b/src/board.rs
@@ -45,21 +45,21 @@ impl Node {
         Node((self.0 & !3) | clipped_height)
     }
 
-    pub(crate) fn color(self) -> Color {
+    pub fn color(self) -> Color {
         // Color enum is densely packed in 1 bit.
         unsafe { std::mem::transmute::<u8, Color>(self.0 >> 7) }
     }
 
-    pub(crate) fn bug(self) -> Bug {
+    pub fn bug(self) -> Bug {
         // Bug enum is densely packed in 3 bits.
         unsafe { std::mem::transmute::<u8, Bug>((self.0 >> 4) & 7) }
     }
 
-    pub(crate) fn bug_num(self) -> u8 {
+    pub fn bug_num(self) -> u8 {
         (self.0 >> 2) & 3
     }
 
-    pub(crate) fn occupied(self) -> bool {
+    pub fn occupied(self) -> bool {
         self.0 != 0
     }
 
@@ -67,7 +67,7 @@ impl Node {
         self.clipped_height() > 1
     }
 
-    pub(crate) fn clipped_height(self) -> u8 {
+    pub fn clipped_height(self) -> u8 {
         self.0 & 0x3
     }
 }
@@ -107,11 +107,11 @@ pub struct Board {
     // Sorted by height (for each hex) and no gaps.
     underworld: [UnderNode; 8],
     underworld_size: usize,
-    pub(crate) remaining: [[u8; 8]; 2],
-    pub(crate) queens: [Hex; 2],
-    pub(crate) occupied_hexes: [Vec<Hex>; 2],
+    pub remaining: [[u8; 8]; 2],
+    pub queens: [Hex; 2],
+    pub occupied_hexes: [Vec<Hex>; 2],
 
-    pub(crate) turn_num: u16,
+    pub turn_num: u16,
     zobrist_table: &'static [u64; GRID_SIZE * 2],
     zobrist_hash: u64,
     zobrist_history: Vec<u64>,
@@ -130,7 +130,7 @@ impl Board {
         }
     }
 
-    pub(crate) fn node(&self, hex: Hex) -> Node {
+    pub fn node(&self, hex: Hex) -> Node {
         self.nodes[hex as usize]
     }
 
@@ -242,7 +242,7 @@ impl Board {
         self.underworld_height(hex, self.node(hex))
     }
 
-    pub(crate) fn occupied(&self, hex: Hex) -> bool {
+    pub fn occupied(&self, hex: Hex) -> bool {
         self.node(hex).occupied()
     }
 
@@ -276,7 +276,7 @@ impl Board {
         self.turn_num > 5 && self.get_remaining()[Bug::Queen as usize] > 0
     }
 
-    pub(crate) fn queens_surrounded(&self) -> [usize; 2] {
+    pub fn queens_surrounded(&self) -> [usize; 2] {
         let mut out = [0; 2];
         for (i, entry) in out.iter_mut().enumerate() {
             *entry = adjacent(self.queens[i]).iter().filter(|adj| self.occupied(**adj)).count();
@@ -942,15 +942,14 @@ impl minimax::Game for Rules {
     }
 }
 
-// Coordinates for populating test positions.
-pub(crate) type Loc = (i8, i8);
+// Relative coordinates centered on START_HEX.
+pub type Loc = (i8, i8);
 pub fn loc_to_hex(loc: Loc) -> Hex {
     // Centered in the middle of the board.
     START_HEX.wrapping_add(ROW_SIZE.wrapping_mul(loc.1 as Hex)).wrapping_add(loc.0 as Hex)
 }
 
-#[cfg(test)]
-pub(crate) fn hex_to_loc(hex: Hex) -> Loc {
+pub fn hex_to_loc(hex: Hex) -> Loc {
     let mut x = (hex.wrapping_sub(START_HEX - ROW_SIZE / 2) / ROW_SIZE) as i8;
     if x > 7 {
         x -= ROW_SIZE as i8;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,3 +26,7 @@ mod uhp_server;
 pub use uhp_server::*;
 #[cfg(target_arch = "wasm32")]
 mod wasm;
+#[cfg(feature = "python")]
+mod python;
+#[cfg(feature = "python")]
+pub use python::*;

--- a/src/notation.rs
+++ b/src/notation.rs
@@ -266,7 +266,7 @@ impl Board {
 
     // https://github.com/jonthysell/Mzinga/wiki/UniversalHiveProtocol#movestring
     #[allow(clippy::wrong_self_convention)]
-    pub(crate) fn from_move_string(&self, move_string: &str) -> Result<Turn> {
+    pub fn from_move_string(&self, move_string: &str) -> Result<Turn> {
         let err = || UhpError::InvalidMove(move_string.to_owned());
         if move_string == "pass" {
             return Ok(Turn::Pass);
@@ -311,7 +311,7 @@ impl Board {
         Ok(Turn::Place(end, bug))
     }
 
-    pub(crate) fn from_game_string(s: &str) -> Result<Self> {
+    pub fn from_game_string(s: &str) -> Result<Self> {
         let mut toks = s.split(';');
         let game_type = toks.next().ok_or_else(|| UhpError::InvalidGameString(s.to_owned()))?;
         let mut board = Board::from_game_type(game_type)?;
@@ -353,7 +353,7 @@ impl Board {
         self.turn_history.last().copied()
     }
 
-    pub(crate) fn valid_moves(&self) -> String {
+    pub fn valid_moves(&self) -> String {
         let mut moves = Vec::new();
         Rules::generate_moves(self, &mut moves);
         let mut out = String::new();

--- a/src/python.rs
+++ b/src/python.rs
@@ -8,8 +8,11 @@ use pyo3::exceptions::PyValueError;
 use crate::board::{Board, Color, Turn, hex_to_loc};
 use crate::bug::Bug;
 use crate::eval::BasicEvaluator;
+use crate::hex_grid::Hex;
 
 use minimax::{Game, Evaluator};
+use numpy::ndarray::Array3;
+use numpy::{IntoPyArray, PyArray3};
 
 /// A Hive game move.
 #[pyclass]
@@ -272,9 +275,116 @@ impl GameState {
         let qs = self.board.queens_surrounded();
         (qs[0], qs[1])
     }
+
+    /// Returns the board tensor as a numpy array of shape (84, 32, 32).
+    fn encode_board<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray3<f32>>> {
+        const BOARD_SIZE: usize = 32;
+        const CENTER: i32 = 16;
+        const PLANE_SIZE: usize = BOARD_SIZE * BOARD_SIZE;
+        const NUM_CHANNELS: usize = 84;
+        const TOTAL: usize = NUM_CHANNELS * PLANE_SIZE;
+
+        let mut data = vec![0.0f32; TOTAL];
+
+        // Determine centering offset.
+        let (offset_q, offset_r) = self.encode_offset();
+
+        // Write piece data (channels 0-79): 5 stack layers x 16 channels.
+        // Collect pieces per hex, sorted by height, to assign layer indices.
+        type Stack = Vec<(Hex, Vec<(u8, Bug, Color)>)>;
+        let mut stacks: Stack = Vec::new();
+
+        // Gather top-of-stack pieces from occupied_hexes.
+        for color_idx in 0..2 {
+            for &hex in &self.board.occupied_hexes[color_idx] {
+                let node = self.board.node(hex);
+                let top_height = node.clipped_height().max(1);
+                // Find or create stack entry for this hex.
+                if let Some(entry) = stacks.iter_mut().find(|(h, _)| *h == hex) {
+                    entry.1.push((top_height, node.bug(), node.color()));
+                } else {
+                    stacks.push((hex, vec![(top_height, node.bug(), node.color())]));
+                }
+            }
+        }
+
+        // Gather underworld (buried) pieces.
+        for under in self.board.get_underworld() {
+            let node = under.node();
+            if !node.occupied() {
+                continue;
+            }
+            let hex = under.hex();
+            let height = under.height();
+            if let Some(entry) = stacks.iter_mut().find(|(h, _)| *h == hex) {
+                entry.1.push((height, node.bug(), node.color()));
+            } else {
+                stacks.push((hex, vec![(height, node.bug(), node.color())]));
+            }
+        }
+
+        // Write each stack to the tensor.
+        for (hex, mut pieces) in stacks {
+            let (q, r) = hex_to_loc(hex);
+            let bq = q as i32 - offset_q + CENTER;
+            let br = r as i32 - offset_r + CENTER;
+            if bq < 0 || bq >= BOARD_SIZE as i32 || br < 0 || br >= BOARD_SIZE as i32 {
+                continue;
+            }
+            let bq = bq as usize;
+            let br = br as usize;
+            let spatial_idx = bq * BOARD_SIZE + br;
+
+            // Sort by height ascending (bottom of stack first).
+            pieces.sort_by_key(|&(h, _, _)| h);
+
+            for (layer_idx, &(_, bug, color)) in pieces.iter().enumerate() {
+                if layer_idx >= 5 {
+                    break;
+                }
+                let piece_type_idx = bug_to_encode_idx(bug);
+                let color_offset = if color == Color::White { 0 } else { 8 };
+                let channel = layer_idx * 16 + color_offset + piece_type_idx;
+                data[channel * PLANE_SIZE + spatial_idx] = 1.0;
+            }
+        }
+
+        // Write global scalar planes (channels 80-83).
+        let current_player = if self.board.to_move() == Color::White { 1.0f32 } else { 0.0 };
+        let turn_normalized = self.board.turn_num as f32 / 200.0;
+        let white_queen_placed =
+            if self.board.remaining[0][Bug::Queen as usize] == 0 { 1.0f32 } else { 0.0 };
+        let black_queen_placed =
+            if self.board.remaining[1][Bug::Queen as usize] == 0 { 1.0f32 } else { 0.0 };
+
+        let globals = [current_player, turn_normalized, white_queen_placed, black_queen_placed];
+        for (i, &value) in globals.iter().enumerate() {
+            let offset = (80 + i) * PLANE_SIZE;
+            data[offset..offset + PLANE_SIZE].fill(value);
+        }
+
+        let array = Array3::from_shape_vec((84, 32, 32), data)
+            .map_err(|e| PyValueError::new_err(format!("Shape error: {}", e)))?;
+        Ok(array.into_pyarray(py))
+    }
 }
 
 // --- Helpers ---
+
+/// Map Bug enum to the tensor encoding piece type index.
+/// Matches bug_name_to_sort_ord ordering.
+fn bug_to_encode_idx(bug: Bug) -> usize {
+    match bug {
+        Bug::Queen => 0,
+        Bug::Beetle => 1,
+        Bug::Grasshopper => 2,
+        Bug::Ant => 3,
+        Bug::Spider => 4,
+        Bug::Mosquito => 5,
+        Bug::Ladybug => 6,
+        Bug::Pillbug => 7,
+    }
+}
 
 /// Sort ordinal for piece types in the canonical action-space ordering.
 /// Intentionally differs from Bug enum discriminants to group pieces intuitively.
@@ -289,6 +399,37 @@ fn bug_name_to_sort_ord(name: &str) -> u8 {
         "ladybug" => 6,
         "pillbug" => 7,
         _ => 255,
+    }
+}
+
+impl GameState {
+    /// Compute the (q, r) centering offset for tensor encoding.
+    fn encode_offset(&self) -> (i32, i32) {
+        // Priority 1: White queen position.
+        if self.board.remaining[0][Bug::Queen as usize] == 0 {
+            let (q, r) = hex_to_loc(self.board.queens[0]);
+            return (q as i32, r as i32);
+        }
+        // Priority 2: Centroid of occupied hexes.
+        let mut sum_q = 0i32;
+        let mut sum_r = 0i32;
+        let mut count = 0i32;
+        for color_hexes in &self.board.occupied_hexes {
+            for &hex in color_hexes {
+                let (q, r) = hex_to_loc(hex);
+                sum_q += q as i32;
+                sum_r += r as i32;
+                count += 1;
+            }
+        }
+        if count > 0 {
+            let avg_q = (sum_q as f32 / count as f32).round() as i32;
+            let avg_r = (sum_r as f32 / count as f32).round() as i32;
+            (avg_q, avg_r)
+        } else {
+            // Priority 3: Empty board.
+            (0, 0)
+        }
     }
 }
 

--- a/src/python.rs
+++ b/src/python.rs
@@ -1,6 +1,5 @@
 //! Python bindings for nokamute via PyO3.
 //!
-//! Exposes GameState, Move, and related types for use from Python.
 //! Build with: `maturin develop --features python`
 
 use pyo3::prelude::*;
@@ -52,14 +51,16 @@ impl PyMove {
         }
     }
 
-    /// Return a canonical sort key for deterministic ordering.
+    /// Canonical sort key for deterministic move ordering.
+    /// Uses a custom piece ordering (not Bug enum discriminant order)
+    /// to group related pieces for more intuitive action-space layout.
     fn sort_key(&self) -> (u8, u8, i8, i8, i8, i8) {
         let move_type_ord = match self.move_type.as_str() {
             "place" => 0,
             "move" => 1,
             _ => 2,
         };
-        let piece_ord = self.piece_type.as_ref().map_or(255, |p| bug_name_to_index(p));
+        let piece_ord = self.piece_type.as_ref().map_or(255, |p| bug_name_to_sort_ord(p));
         (
             move_type_ord,
             piece_ord,
@@ -71,7 +72,6 @@ impl PyMove {
     }
 }
 
-/// Piece information tuple: (piece_type, color, q, r, stack_height)
 #[pyclass]
 #[derive(Clone)]
 pub struct PyPiece {
@@ -101,15 +101,21 @@ impl PyPiece {
     }
 }
 
-/// Main game state wrapper around nokamute's Board.
 #[pyclass]
 pub struct GameState {
     board: Board,
 }
 
+fn color_to_player(c: Color) -> i8 {
+    match c {
+        Color::White => 1,
+        Color::Black => -1,
+    }
+}
+
 #[pymethods]
 impl GameState {
-    /// Create a new game. Optionally pass a UHP game string to restore state.
+    /// Optionally pass a UHP game string to restore state.
     #[new]
     #[pyo3(signature = (uhp_string=None))]
     fn new(uhp_string: Option<&str>) -> PyResult<Self> {
@@ -125,83 +131,78 @@ impl GameState {
         }
     }
 
-    /// Deep clone the game state.
     fn clone(&self) -> GameState {
         GameState {
             board: self.board.clone(),
         }
     }
 
-    /// Get the current player: 1 for White, -1 for Black.
+    /// 1 for White, -1 for Black.
     fn current_player(&self) -> i8 {
-        match self.board.to_move() {
-            Color::White => 1,
-            Color::Black => -1,
-        }
+        color_to_player(self.board.to_move())
     }
 
-    /// Get the current turn number (0-indexed).
     fn turn_number(&self) -> u16 {
         self.board.turn_num
     }
 
-    /// Check if the game is over.
     fn is_over(&self) -> bool {
         crate::board::Rules::get_winner(&self.board).is_some()
     }
 
-    /// Get the winner: 1 (White), -1 (Black), 0 (draw).
-    /// Returns 0 if game is not over.
-    fn winner(&self) -> i8 {
+    /// Returns 1 (White), -1 (Black), 0 (draw), or None if game is not over.
+    fn game_result(&self) -> Option<i8> {
         match crate::board::Rules::get_winner(&self.board) {
-            Some(minimax::Winner::PlayerToMove) => self.current_player(),
-            Some(minimax::Winner::PlayerJustMoved) => -self.current_player(),
-            Some(minimax::Winner::Draw) => 0,
-            None => 0,
+            Some(minimax::Winner::PlayerToMove) => Some(self.current_player()),
+            Some(minimax::Winner::PlayerJustMoved) => Some(-self.current_player()),
+            Some(minimax::Winner::Draw) => Some(0),
+            None => None,
         }
     }
 
-    /// Get all legal moves as a list of PyMove objects.
+    /// Returns 1 (White), -1 (Black), 0 (draw or not over).
+    fn winner(&self) -> i8 {
+        self.game_result().unwrap_or(0)
+    }
+
     fn legal_moves(&self) -> Vec<PyMove> {
         let mut turns = Vec::new();
         crate::board::Rules::generate_moves(&self.board, &mut turns);
-        turns.into_iter().map(|t| turn_to_pymove(&self.board, t)).collect()
+        let mut moves = Vec::with_capacity(turns.len());
+        for t in turns {
+            moves.push(turn_to_pymove(&self.board, t));
+        }
+        moves
     }
 
-    /// Apply a move to the game state (mutates in place).
     fn apply_move(&mut self, pymove: &PyMove) {
         self.board.apply(pymove.turn);
     }
 
-    /// Undo the last applied move.
     fn undo_move(&mut self, pymove: &PyMove) {
         self.board.undo(pymove.turn);
     }
 
-    /// Get all pieces on the board, including stacked pieces.
-    /// Returns a list of PyPiece objects with (piece_type, color, q, r, stack_height).
     fn pieces(&self) -> Vec<PyPiece> {
-        let mut result = Vec::new();
+        let capacity = self.board.occupied_hexes[0].len()
+            + self.board.occupied_hexes[1].len()
+            + self.board.get_underworld().len();
+        let mut result = Vec::with_capacity(capacity);
 
         for color_idx in 0..2 {
-
             for &hex in &self.board.occupied_hexes[color_idx] {
                 let node = self.board.node(hex);
                 let (q, r) = hex_to_loc(hex);
-                let height = node.clipped_height();
-
-                // Top piece
                 result.push(PyPiece {
-                    piece_type: bug_to_string(node.bug()),
-                    color: if node.color() == Color::White { 1 } else { -1 },
+                    piece_type: node.bug().name().to_string(),
+                    color: color_to_player(node.color()),
                     q,
                     r,
-                    stack_height: height.max(1),
+                    stack_height: node.clipped_height().max(1),
                 });
             }
         }
 
-        // Add underworld pieces (pieces under stacks)
         for under in self.board.get_underworld() {
             let node = under.node();
             if !node.occupied() {
@@ -209,8 +210,8 @@ impl GameState {
             }
             let (q, r) = hex_to_loc(under.hex());
             result.push(PyPiece {
-                piece_type: bug_to_string(node.bug()),
-                color: if node.color() == Color::White { 1 } else { -1 },
+                piece_type: node.bug().name().to_string(),
+                color: color_to_player(node.color()),
                 q,
                 r,
                 stack_height: node.clipped_height().max(1),
@@ -220,74 +221,64 @@ impl GameState {
         result
     }
 
-    /// Get the UHP game string representation.
     fn game_string(&self) -> String {
         self.board.game_string()
     }
 
-    /// Get the UHP move string for a move.
     fn move_string(&self, pymove: &PyMove) -> String {
         self.board.to_move_string(pymove.turn)
     }
 
-    /// Parse a UHP move string into a PyMove.
     fn parse_move(&self, move_string: &str) -> PyResult<PyMove> {
         let turn = self.board.from_move_string(move_string)
             .map_err(|e| PyValueError::new_err(format!("Invalid move string: {:?}", e)))?;
         Ok(turn_to_pymove(&self.board, turn))
     }
 
-    /// Get all valid moves as UHP strings.
     fn valid_moves_uhp(&self) -> String {
         self.board.valid_moves()
     }
 
-    /// Evaluate the current position using nokamute's heuristic.
-    /// Returns a score from the current player's perspective.
+    /// Heuristic score from the current player's perspective.
     fn evaluate(&self) -> f64 {
         let eval = BasicEvaluator::default();
-        let score = eval.evaluate(&self.board);
-        score as f64
+        eval.evaluate(&self.board) as f64
     }
 
-    /// Get the game type string (e.g., "Base+MLP").
     fn game_type(&self) -> String {
         self.board.game_type()
     }
 
-    /// Check if White's queen has been placed.
+    fn queen_placed(&self, player: i8) -> PyResult<bool> {
+        let color_idx = match player {
+            1 => 0,
+            -1 => 1,
+            _ => return Err(PyValueError::new_err("player must be 1 or -1")),
+        };
+        Ok(self.board.remaining[color_idx][Bug::Queen as usize] == 0)
+    }
+
+    /// Kept for convenience; prefer queen_placed(1) / queen_placed(-1).
     fn white_queen_placed(&self) -> bool {
         self.board.remaining[0][Bug::Queen as usize] == 0
     }
 
-    /// Check if Black's queen has been placed.
     fn black_queen_placed(&self) -> bool {
         self.board.remaining[1][Bug::Queen as usize] == 0
     }
 
-    /// Get the number of neighbors surrounding each queen: [black_count, white_count].
+    /// Returns (white_neighbor_count, black_neighbor_count).
     fn queens_neighbor_count(&self) -> (usize, usize) {
         let qs = self.board.queens_surrounded();
         (qs[0], qs[1])
     }
 }
 
-// Helper functions
+// --- Helpers ---
 
-fn bug_to_string(bug: Bug) -> String {
-    match bug {
-        Bug::Queen => "queen",
-        Bug::Grasshopper => "grasshopper",
-        Bug::Spider => "spider",
-        Bug::Ant => "ant",
-        Bug::Beetle => "beetle",
-        Bug::Mosquito => "mosquito",
-        Bug::Ladybug => "ladybug",
-        Bug::Pillbug => "pillbug",
-    }.to_string()
-}
-
-fn bug_name_to_index(name: &str) -> u8 {
+/// Sort ordinal for piece types in the canonical action-space ordering.
+/// Intentionally differs from Bug enum discriminants to group pieces intuitively.
+fn bug_name_to_sort_ord(name: &str) -> u8 {
     match name {
         "queen" => 0,
         "beetle" => 1,
@@ -308,7 +299,7 @@ fn turn_to_pymove(board: &Board, turn: Turn) -> PyMove {
             PyMove {
                 turn,
                 move_type: "place".to_string(),
-                piece_type: Some(bug_to_string(bug)),
+                piece_type: Some(bug.name().to_string()),
                 source_q: None,
                 source_r: None,
                 dest_q: Some(q),
@@ -318,17 +309,11 @@ fn turn_to_pymove(board: &Board, turn: Turn) -> PyMove {
         Turn::Move(src, dst) => {
             let (sq, sr) = hex_to_loc(src);
             let (dq, dr) = hex_to_loc(dst);
-            // Get the piece type at the source
             let node = board.node(src);
-            let piece_type = if node.occupied() {
-                Some(bug_to_string(node.bug()))
-            } else {
-                None
-            };
             PyMove {
                 turn,
                 move_type: "move".to_string(),
-                piece_type,
+                piece_type: Some(node.bug().name().to_string()),
                 source_q: Some(sq),
                 source_r: Some(sr),
                 dest_q: Some(dq),
@@ -347,7 +332,6 @@ fn turn_to_pymove(board: &Board, turn: Turn) -> PyMove {
     }
 }
 
-/// nokamute Python module
 #[pymodule]
 pub fn nokamute(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<GameState>()?;

--- a/src/python.rs
+++ b/src/python.rs
@@ -2,16 +2,20 @@
 //!
 //! Build with: `maturin develop --features python`
 
+#[cfg(feature = "smaller-grid")]
+compile_error!("Python bindings require the default 32x32 grid. Disable the `smaller-grid` feature.");
+
 use pyo3::prelude::*;
 use pyo3::exceptions::PyValueError;
 
 use crate::board::{Board, Color, Turn, hex_to_loc};
 use crate::bug::Bug;
 use crate::eval::BasicEvaluator;
-use crate::hex_grid::Hex;
+use crate::hex_grid::{Hex, GRID_SIZE};
 
-use minimax::{Game, Evaluator};
+use minimax::{Game, Evaluator, IterativeOptions, IterativeSearch, Strategy};
 use numpy::ndarray::Array3;
+use std::time::Duration;
 use numpy::{IntoPyArray, PyArray3};
 
 /// A Hive game move.
@@ -101,6 +105,29 @@ impl PyPiece {
 
     fn as_tuple(&self) -> (String, i8, i8, i8, u8) {
         (self.piece_type.clone(), self.color, self.q, self.r, self.stack_height)
+    }
+}
+
+#[pyclass]
+#[derive(Clone)]
+pub struct PySearchResult {
+    #[pyo3(get)]
+    pub best_move: PyMove,
+    #[pyo3(get)]
+    pub score: f64,
+    #[pyo3(get)]
+    pub depth: u8,
+}
+
+#[pymethods]
+impl PySearchResult {
+    fn __repr__(&self) -> String {
+        format!(
+            "SearchResult(move={}, score={:.1}, depth={})",
+            self.best_move.__repr__(),
+            self.score,
+            self.depth,
+        )
     }
 }
 
@@ -276,93 +303,23 @@ impl GameState {
         (qs[0], qs[1])
     }
 
+    /// Search for the best move using iterative deepening alpha-beta.
+    /// At least one of `depth` or `timeout_ms` must be provided.
+    #[pyo3(signature = (depth=None, timeout_ms=None))]
+    fn search(&self, depth: Option<u8>, timeout_ms: Option<u64>) -> PyResult<PyMove> {
+        let result = self.run_search(depth, timeout_ms)?;
+        Ok(result.best_move)
+    }
+
+    /// Like search(), but returns a PySearchResult with score and depth info.
+    #[pyo3(signature = (depth=None, timeout_ms=None))]
+    fn search_with_info(&self, depth: Option<u8>, timeout_ms: Option<u64>) -> PyResult<PySearchResult> {
+        self.run_search(depth, timeout_ms)
+    }
+
     /// Returns the board tensor as a numpy array of shape (84, 32, 32).
     fn encode_board<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray3<f32>>> {
-        const BOARD_SIZE: usize = 32;
-        const CENTER: i32 = 16;
-        const PLANE_SIZE: usize = BOARD_SIZE * BOARD_SIZE;
-        const NUM_CHANNELS: usize = 84;
-        const TOTAL: usize = NUM_CHANNELS * PLANE_SIZE;
-
-        let mut data = vec![0.0f32; TOTAL];
-
-        // Determine centering offset.
-        let (offset_q, offset_r) = self.encode_offset();
-
-        // Write piece data (channels 0-79): 5 stack layers x 16 channels.
-        // Collect pieces per hex, sorted by height, to assign layer indices.
-        type Stack = Vec<(Hex, Vec<(u8, Bug, Color)>)>;
-        let mut stacks: Stack = Vec::new();
-
-        // Gather top-of-stack pieces from occupied_hexes.
-        for color_idx in 0..2 {
-            for &hex in &self.board.occupied_hexes[color_idx] {
-                let node = self.board.node(hex);
-                let top_height = node.clipped_height().max(1);
-                // Find or create stack entry for this hex.
-                if let Some(entry) = stacks.iter_mut().find(|(h, _)| *h == hex) {
-                    entry.1.push((top_height, node.bug(), node.color()));
-                } else {
-                    stacks.push((hex, vec![(top_height, node.bug(), node.color())]));
-                }
-            }
-        }
-
-        // Gather underworld (buried) pieces.
-        for under in self.board.get_underworld() {
-            let node = under.node();
-            if !node.occupied() {
-                continue;
-            }
-            let hex = under.hex();
-            let height = under.height();
-            if let Some(entry) = stacks.iter_mut().find(|(h, _)| *h == hex) {
-                entry.1.push((height, node.bug(), node.color()));
-            } else {
-                stacks.push((hex, vec![(height, node.bug(), node.color())]));
-            }
-        }
-
-        // Write each stack to the tensor.
-        for (hex, mut pieces) in stacks {
-            let (q, r) = hex_to_loc(hex);
-            let bq = q as i32 - offset_q + CENTER;
-            let br = r as i32 - offset_r + CENTER;
-            if bq < 0 || bq >= BOARD_SIZE as i32 || br < 0 || br >= BOARD_SIZE as i32 {
-                continue;
-            }
-            let bq = bq as usize;
-            let br = br as usize;
-            let spatial_idx = bq * BOARD_SIZE + br;
-
-            // Sort by height ascending (bottom of stack first).
-            pieces.sort_by_key(|&(h, _, _)| h);
-
-            for (layer_idx, &(_, bug, color)) in pieces.iter().enumerate() {
-                if layer_idx >= 5 {
-                    break;
-                }
-                let piece_type_idx = bug_to_encode_idx(bug);
-                let color_offset = if color == Color::White { 0 } else { 8 };
-                let channel = layer_idx * 16 + color_offset + piece_type_idx;
-                data[channel * PLANE_SIZE + spatial_idx] = 1.0;
-            }
-        }
-
-        // Write global scalar planes (channels 80-83).
-        let current_player = if self.board.to_move() == Color::White { 1.0f32 } else { 0.0 };
-        let turn_normalized = self.board.turn_num as f32 / 200.0;
-        let white_queen_placed =
-            if self.board.remaining[0][Bug::Queen as usize] == 0 { 1.0f32 } else { 0.0 };
-        let black_queen_placed =
-            if self.board.remaining[1][Bug::Queen as usize] == 0 { 1.0f32 } else { 0.0 };
-
-        let globals = [current_player, turn_normalized, white_queen_placed, black_queen_placed];
-        for (i, &value) in globals.iter().enumerate() {
-            let offset = (80 + i) * PLANE_SIZE;
-            data[offset..offset + PLANE_SIZE].fill(value);
-        }
-
+        let data = self.encode_board_data();
         let array = Array3::from_shape_vec((84, 32, 32), data)
             .map_err(|e| PyValueError::new_err(format!("Shape error: {}", e)))?;
         Ok(array.into_pyarray(py))
@@ -371,9 +328,9 @@ impl GameState {
 
 // --- Helpers ---
 
-/// Map Bug enum to the tensor encoding piece type index.
-/// Matches bug_name_to_sort_ord ordering.
-fn bug_to_encode_idx(bug: Bug) -> usize {
+/// Canonical sort ordinal for piece types in the action-space and tensor encoding.
+/// Intentionally differs from Bug enum discriminants to group pieces intuitively.
+fn bug_sort_ord(bug: Bug) -> u8 {
     match bug {
         Bug::Queen => 0,
         Bug::Beetle => 1,
@@ -386,31 +343,147 @@ fn bug_to_encode_idx(bug: Bug) -> usize {
     }
 }
 
-/// Sort ordinal for piece types in the canonical action-space ordering.
-/// Intentionally differs from Bug enum discriminants to group pieces intuitively.
 fn bug_name_to_sort_ord(name: &str) -> u8 {
-    match name {
-        "queen" => 0,
-        "beetle" => 1,
-        "grasshopper" => 2,
-        "ant" => 3,
-        "spider" => 4,
-        "mosquito" => 5,
-        "ladybug" => 6,
-        "pillbug" => 7,
-        _ => 255,
+    name.chars()
+        .next()
+        .and_then(Bug::from_char)
+        .map(bug_sort_ord)
+        .unwrap_or(255)
+}
+
+/// Pure-Rust search result (no PyO3 dependency) for testability.
+struct RawSearchResult {
+    turn: Turn,
+    score: f64,
+    depth: u8,
+}
+
+/// Run iterative-deepening alpha-beta search. Pure Rust, no PyO3 types.
+fn run_search_raw(
+    board: &Board, depth: Option<u8>, timeout_ms: Option<u64>,
+) -> Result<RawSearchResult, &'static str> {
+    if depth.is_none() && timeout_ms.is_none() {
+        return Err("At least one of `depth` or `timeout_ms` must be provided");
     }
+
+    let opts = IterativeOptions::new()
+        .with_table_byte_size(16 << 20)
+        .with_countermoves()
+        .with_countermove_history();
+    let mut strategy = IterativeSearch::new(BasicEvaluator::default(), opts);
+
+    match (depth, timeout_ms) {
+        (Some(d), Some(t)) => {
+            strategy.set_depth_or_timeout(d, Duration::from_millis(t));
+        }
+        (Some(d), None) => {
+            strategy.set_max_depth(d);
+        }
+        (None, Some(t)) => {
+            strategy.set_timeout(Duration::from_millis(t));
+        }
+        (None, None) => unreachable!(),
+    }
+
+    let turn = strategy.choose_move(board).ok_or("No legal moves available")?;
+    let score = strategy.root_value() as f64;
+    let pv_depth = strategy.principal_variation().len() as u8;
+
+    Ok(RawSearchResult { turn, score, depth: pv_depth })
 }
 
 impl GameState {
-    /// Compute the (q, r) centering offset for tensor encoding.
+    fn run_search(&self, depth: Option<u8>, timeout_ms: Option<u64>) -> PyResult<PySearchResult> {
+        let raw = run_search_raw(&self.board, depth, timeout_ms)
+            .map_err(PyValueError::new_err)?;
+        Ok(PySearchResult {
+            best_move: turn_to_pymove(&self.board, raw.turn),
+            score: raw.score,
+            depth: raw.depth,
+        })
+    }
+
+    fn encode_board_data(&self) -> Vec<f32> {
+        const BOARD_SIZE: usize = 32;
+        const CENTER: i32 = 16;
+        const PLANE_SIZE: usize = BOARD_SIZE * BOARD_SIZE;
+        const NUM_CHANNELS: usize = 84;
+        const MAX_STACK: usize = 5;
+
+        let mut data = vec![0.0f32; NUM_CHANNELS * PLANE_SIZE];
+        let (offset_q, offset_r) = self.encode_offset();
+
+        let mut stack_counts = [0u8; GRID_SIZE];
+        let mut stack_data = [[(0u8, Bug::Queen, Color::White); MAX_STACK]; GRID_SIZE];
+
+        for color_idx in 0..2 {
+            for &hex in &self.board.occupied_hexes[color_idx] {
+                let node = self.board.node(hex);
+                let idx = hex as usize;
+                let n = stack_counts[idx] as usize;
+                if n < MAX_STACK {
+                    stack_data[idx][n] =
+                        (node.clipped_height().max(1), node.bug(), node.color());
+                    stack_counts[idx] += 1;
+                }
+            }
+        }
+        for under in self.board.get_underworld() {
+            let node = under.node();
+            if !node.occupied() {
+                continue;
+            }
+            let idx = under.hex() as usize;
+            let n = stack_counts[idx] as usize;
+            if n < MAX_STACK {
+                stack_data[idx][n] = (under.height(), node.bug(), node.color());
+                stack_counts[idx] += 1;
+            }
+        }
+
+        for hex_idx in 0..GRID_SIZE {
+            let n = stack_counts[hex_idx] as usize;
+            if n == 0 {
+                continue;
+            }
+            let (q, r) = hex_to_loc(hex_idx as Hex);
+            let bq = q as i32 - offset_q + CENTER;
+            let br = r as i32 - offset_r + CENTER;
+            if bq < 0 || bq >= BOARD_SIZE as i32 || br < 0 || br >= BOARD_SIZE as i32 {
+                continue;
+            }
+            let spatial_idx = bq as usize * BOARD_SIZE + br as usize;
+
+            let pieces = &mut stack_data[hex_idx][..n];
+            pieces.sort_by_key(|&(h, _, _)| h);
+
+            for (layer_idx, &(_, bug, color)) in pieces.iter().enumerate() {
+                let color_offset = if color == Color::White { 0 } else { 8 };
+                let channel = layer_idx * 16 + color_offset + bug_sort_ord(bug) as usize;
+                data[channel * PLANE_SIZE + spatial_idx] = 1.0;
+            }
+        }
+
+        let current_player = if self.board.to_move() == Color::White { 1.0f32 } else { 0.0 };
+        // 200 is a generous upper bound on Hive game length for normalization.
+        let turn_normalized = self.board.turn_num as f32 / 200.0;
+        let white_qp = if self.white_queen_placed() { 1.0f32 } else { 0.0 };
+        let black_qp = if self.black_queen_placed() { 1.0f32 } else { 0.0 };
+
+        for (i, &value) in [current_player, turn_normalized, white_qp, black_qp].iter().enumerate()
+        {
+            let offset = (80 + i) * PLANE_SIZE;
+            data[offset..offset + PLANE_SIZE].fill(value);
+        }
+
+        data
+    }
+
     fn encode_offset(&self) -> (i32, i32) {
-        // Priority 1: White queen position.
-        if self.board.remaining[0][Bug::Queen as usize] == 0 {
+        if self.white_queen_placed() {
             let (q, r) = hex_to_loc(self.board.queens[0]);
             return (q as i32, r as i32);
         }
-        // Priority 2: Centroid of occupied hexes.
         let mut sum_q = 0i32;
         let mut sum_r = 0i32;
         let mut count = 0i32;
@@ -427,7 +500,6 @@ impl GameState {
             let avg_r = (sum_r as f32 / count as f32).round() as i32;
             (avg_q, avg_r)
         } else {
-            // Priority 3: Empty board.
             (0, 0)
         }
     }
@@ -478,5 +550,150 @@ pub fn nokamute(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<GameState>()?;
     m.add_class::<PyMove>()?;
     m.add_class::<PyPiece>()?;
+    m.add_class::<PySearchResult>()?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::board::{loc_to_hex, Turn};
+
+    const P: usize = 32 * 32; // plane size
+
+    fn make_state() -> GameState {
+        GameState { board: Board::new_expansions() }
+    }
+
+    fn assert_legal_move(board: &Board, turn: Turn) {
+        let mut moves = Vec::new();
+        crate::board::Rules::generate_moves(board, &mut moves);
+        assert!(moves.contains(&turn), "move {:?} is not legal", turn);
+    }
+
+    #[test]
+    fn test_bug_sort_ord_matches_names() {
+        for bug in Bug::iter_all() {
+            assert_eq!(bug_sort_ord(bug), bug_name_to_sort_ord(bug.name()),
+                "mismatch for {:?}", bug);
+        }
+    }
+
+    #[test]
+    fn test_encode_offset_empty_board() {
+        assert_eq!(make_state().encode_offset(), (0, 0));
+    }
+
+    #[test]
+    fn test_encode_offset_queen_centering() {
+        let mut gs = make_state();
+        gs.board.apply(Turn::Place(loc_to_hex((2, 3)), Bug::Queen));
+        gs.board.apply(Turn::Place(loc_to_hex((3, 3)), Bug::Ant));
+        assert_eq!(gs.encode_offset(), (2, 3));
+    }
+
+    #[test]
+    fn test_encode_offset_centroid_before_queen() {
+        let mut gs = make_state();
+        gs.board.apply(Turn::Place(loc_to_hex((0, 0)), Bug::Ant));
+        gs.board.apply(Turn::Place(loc_to_hex((1, 0)), Bug::Ant));
+        assert_eq!(gs.encode_offset().1, 0);
+    }
+
+    #[test]
+    fn test_encode_board_empty() {
+        let data = make_state().encode_board_data();
+        assert_eq!(data.len(), 84 * P);
+        // Spatial channels all zero.
+        assert!(data[..80 * P].iter().all(|&v| v == 0.0));
+        // White to move.
+        assert_eq!(data[80 * P], 1.0);
+        // Turn 0.
+        assert_eq!(data[81 * P], 0.0);
+        // Queens not placed.
+        assert_eq!(data[82 * P], 0.0);
+        assert_eq!(data[83 * P], 0.0);
+    }
+
+    #[test]
+    fn test_encode_board_single_piece() {
+        let mut gs = make_state();
+        gs.board.apply(Turn::Place(loc_to_hex((0, 0)), Bug::Ant));
+        let data = gs.encode_board_data();
+
+        // White ant at center (16,16): channel 3, spatial 16*32+16.
+        let spatial_idx = 16 * 32 + 16;
+        assert_eq!(data[3 * P + spatial_idx], 1.0);
+
+        // Exactly one nonzero in spatial channels.
+        let nonzeros = data[..80 * P].iter().filter(|&&v| v != 0.0).count();
+        assert_eq!(nonzeros, 1);
+
+        // Black to move.
+        assert_eq!(data[80 * P], 0.0);
+        // Turn 1/200.
+        assert!((data[81 * P] - 0.005).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_encode_board_queen_centering() {
+        let mut gs = make_state();
+        gs.board.apply(Turn::Place(loc_to_hex((2, 1)), Bug::Queen));
+        gs.board.apply(Turn::Place(loc_to_hex((3, 1)), Bug::Ant));
+        let data = gs.encode_board_data();
+
+        // Queen centered at (16, 16).
+        let queen_spatial = 16 * 32 + 16;
+        assert_eq!(data[0 * P + queen_spatial], 1.0); // channel 0: white queen
+
+        // Black ant at (17, 16).
+        let ant_spatial = 17 * 32 + 16;
+        assert_eq!(data[11 * P + ant_spatial], 1.0); // channel 8+3: black ant
+
+        // White queen placed, black not.
+        assert_eq!(data[82 * P], 1.0);
+        assert_eq!(data[83 * P], 0.0);
+    }
+
+    #[test]
+    fn test_search_requires_params() {
+        let gs = make_state();
+        assert!(run_search_raw(&gs.board, None, None).is_err());
+    }
+
+    #[test]
+    fn test_search_with_depth() {
+        let mut gs = make_state();
+        gs.board.apply(Turn::Place(loc_to_hex((0, 0)), Bug::Queen));
+        gs.board.apply(Turn::Place(loc_to_hex((1, 0)), Bug::Queen));
+        let result = run_search_raw(&gs.board, Some(3), None).unwrap();
+        assert_legal_move(&gs.board, result.turn);
+        assert!(result.depth > 0);
+    }
+
+    #[test]
+    fn test_search_with_timeout() {
+        let mut gs = make_state();
+        gs.board.apply(Turn::Place(loc_to_hex((0, 0)), Bug::Queen));
+        gs.board.apply(Turn::Place(loc_to_hex((1, 0)), Bug::Queen));
+        let result = run_search_raw(&gs.board, None, Some(100)).unwrap();
+        assert_legal_move(&gs.board, result.turn);
+    }
+
+    #[test]
+    fn test_search_finds_winning_move() {
+        // Same position from test_minimax in eval.rs — white ant can win.
+        let mut gs = make_state();
+        gs.board.apply(Turn::Place(loc_to_hex((0, 0)), Bug::Queen));
+        gs.board.apply(Turn::Place(loc_to_hex((1, 0)), Bug::Spider));
+        gs.board.apply(Turn::Place(loc_to_hex((-1, 1)), Bug::Ant));
+        gs.board.apply(Turn::Place(loc_to_hex((0, 1)), Bug::Ant));
+        gs.board.apply(Turn::Place(loc_to_hex((1, 2)), Bug::Grasshopper));
+        gs.board.apply(Turn::Place(loc_to_hex((1, 1)), Bug::Queen));
+        gs.board.apply(Turn::Place(loc_to_hex((2, 2)), Bug::Beetle));
+        gs.board.apply(Turn::Pass);
+        let result = run_search_raw(&gs.board, Some(2), None).unwrap();
+        // The winning move is Ant from (-1,1) to (2,1).
+        assert_eq!(result.turn, Turn::Move(loc_to_hex((-1, 1)), loc_to_hex((2, 1))));
+    }
 }

--- a/src/python.rs
+++ b/src/python.rs
@@ -1,0 +1,357 @@
+//! Python bindings for nokamute via PyO3.
+//!
+//! Exposes GameState, Move, and related types for use from Python.
+//! Build with: `maturin develop --features python`
+
+use pyo3::prelude::*;
+use pyo3::exceptions::PyValueError;
+
+use crate::board::{Board, Color, Turn, hex_to_loc};
+use crate::bug::Bug;
+use crate::eval::BasicEvaluator;
+
+use minimax::{Game, Evaluator};
+
+/// A Hive game move.
+#[pyclass]
+#[derive(Clone)]
+pub struct PyMove {
+    pub(crate) turn: Turn,
+    #[pyo3(get)]
+    pub move_type: String,
+    #[pyo3(get)]
+    pub piece_type: Option<String>,
+    #[pyo3(get)]
+    pub source_q: Option<i8>,
+    #[pyo3(get)]
+    pub source_r: Option<i8>,
+    #[pyo3(get)]
+    pub dest_q: Option<i8>,
+    #[pyo3(get)]
+    pub dest_r: Option<i8>,
+}
+
+#[pymethods]
+impl PyMove {
+    fn __repr__(&self) -> String {
+        match self.move_type.as_str() {
+            "place" => format!(
+                "Move(place, {}, ({}, {}))",
+                self.piece_type.as_deref().unwrap_or("?"),
+                self.dest_q.unwrap_or(0),
+                self.dest_r.unwrap_or(0),
+            ),
+            "move" => format!(
+                "Move(move, ({}, {})->({}, {}))",
+                self.source_q.unwrap_or(0),
+                self.source_r.unwrap_or(0),
+                self.dest_q.unwrap_or(0),
+                self.dest_r.unwrap_or(0),
+            ),
+            _ => "Move(pass)".to_string(),
+        }
+    }
+
+    /// Return a canonical sort key for deterministic ordering.
+    fn sort_key(&self) -> (u8, u8, i8, i8, i8, i8) {
+        let move_type_ord = match self.move_type.as_str() {
+            "place" => 0,
+            "move" => 1,
+            _ => 2,
+        };
+        let piece_ord = self.piece_type.as_ref().map_or(255, |p| bug_name_to_index(p));
+        (
+            move_type_ord,
+            piece_ord,
+            self.source_q.unwrap_or(0),
+            self.source_r.unwrap_or(0),
+            self.dest_q.unwrap_or(0),
+            self.dest_r.unwrap_or(0),
+        )
+    }
+}
+
+/// Piece information tuple: (piece_type, color, q, r, stack_height)
+#[pyclass]
+#[derive(Clone)]
+pub struct PyPiece {
+    #[pyo3(get)]
+    pub piece_type: String,
+    #[pyo3(get)]
+    pub color: i8,
+    #[pyo3(get)]
+    pub q: i8,
+    #[pyo3(get)]
+    pub r: i8,
+    #[pyo3(get)]
+    pub stack_height: u8,
+}
+
+#[pymethods]
+impl PyPiece {
+    fn __repr__(&self) -> String {
+        format!(
+            "Piece({}, color={}, ({}, {}), height={})",
+            self.piece_type, self.color, self.q, self.r, self.stack_height
+        )
+    }
+
+    fn as_tuple(&self) -> (String, i8, i8, i8, u8) {
+        (self.piece_type.clone(), self.color, self.q, self.r, self.stack_height)
+    }
+}
+
+/// Main game state wrapper around nokamute's Board.
+#[pyclass]
+pub struct GameState {
+    board: Board,
+}
+
+#[pymethods]
+impl GameState {
+    /// Create a new game. Optionally pass a UHP game string to restore state.
+    #[new]
+    #[pyo3(signature = (uhp_string=None))]
+    fn new(uhp_string: Option<&str>) -> PyResult<Self> {
+        match uhp_string {
+            Some(s) => {
+                let board = Board::from_game_string(s)
+                    .map_err(|e| PyValueError::new_err(format!("Invalid UHP string: {:?}", e)))?;
+                Ok(GameState { board })
+            }
+            None => Ok(GameState {
+                board: Board::new_expansions(),
+            }),
+        }
+    }
+
+    /// Deep clone the game state.
+    fn clone(&self) -> GameState {
+        GameState {
+            board: self.board.clone(),
+        }
+    }
+
+    /// Get the current player: 1 for White, -1 for Black.
+    fn current_player(&self) -> i8 {
+        match self.board.to_move() {
+            Color::White => 1,
+            Color::Black => -1,
+        }
+    }
+
+    /// Get the current turn number (0-indexed).
+    fn turn_number(&self) -> u16 {
+        self.board.turn_num
+    }
+
+    /// Check if the game is over.
+    fn is_over(&self) -> bool {
+        crate::board::Rules::get_winner(&self.board).is_some()
+    }
+
+    /// Get the winner: 1 (White), -1 (Black), 0 (draw).
+    /// Returns 0 if game is not over.
+    fn winner(&self) -> i8 {
+        match crate::board::Rules::get_winner(&self.board) {
+            Some(minimax::Winner::PlayerToMove) => self.current_player(),
+            Some(minimax::Winner::PlayerJustMoved) => -self.current_player(),
+            Some(minimax::Winner::Draw) => 0,
+            None => 0,
+        }
+    }
+
+    /// Get all legal moves as a list of PyMove objects.
+    fn legal_moves(&self) -> Vec<PyMove> {
+        let mut turns = Vec::new();
+        crate::board::Rules::generate_moves(&self.board, &mut turns);
+        turns.into_iter().map(|t| turn_to_pymove(&self.board, t)).collect()
+    }
+
+    /// Apply a move to the game state (mutates in place).
+    fn apply_move(&mut self, pymove: &PyMove) {
+        self.board.apply(pymove.turn);
+    }
+
+    /// Undo the last applied move.
+    fn undo_move(&mut self, pymove: &PyMove) {
+        self.board.undo(pymove.turn);
+    }
+
+    /// Get all pieces on the board, including stacked pieces.
+    /// Returns a list of PyPiece objects with (piece_type, color, q, r, stack_height).
+    fn pieces(&self) -> Vec<PyPiece> {
+        let mut result = Vec::new();
+
+        for color_idx in 0..2 {
+
+            for &hex in &self.board.occupied_hexes[color_idx] {
+                let node = self.board.node(hex);
+                let (q, r) = hex_to_loc(hex);
+                let height = node.clipped_height();
+
+                // Top piece
+                result.push(PyPiece {
+                    piece_type: bug_to_string(node.bug()),
+                    color: if node.color() == Color::White { 1 } else { -1 },
+                    q,
+                    r,
+                    stack_height: height.max(1),
+                });
+            }
+        }
+
+        // Add underworld pieces (pieces under stacks)
+        for under in self.board.get_underworld() {
+            let node = under.node();
+            if !node.occupied() {
+                continue;
+            }
+            let (q, r) = hex_to_loc(under.hex());
+            result.push(PyPiece {
+                piece_type: bug_to_string(node.bug()),
+                color: if node.color() == Color::White { 1 } else { -1 },
+                q,
+                r,
+                stack_height: node.clipped_height().max(1),
+            });
+        }
+
+        result
+    }
+
+    /// Get the UHP game string representation.
+    fn game_string(&self) -> String {
+        self.board.game_string()
+    }
+
+    /// Get the UHP move string for a move.
+    fn move_string(&self, pymove: &PyMove) -> String {
+        self.board.to_move_string(pymove.turn)
+    }
+
+    /// Parse a UHP move string into a PyMove.
+    fn parse_move(&self, move_string: &str) -> PyResult<PyMove> {
+        let turn = self.board.from_move_string(move_string)
+            .map_err(|e| PyValueError::new_err(format!("Invalid move string: {:?}", e)))?;
+        Ok(turn_to_pymove(&self.board, turn))
+    }
+
+    /// Get all valid moves as UHP strings.
+    fn valid_moves_uhp(&self) -> String {
+        self.board.valid_moves()
+    }
+
+    /// Evaluate the current position using nokamute's heuristic.
+    /// Returns a score from the current player's perspective.
+    fn evaluate(&self) -> f64 {
+        let eval = BasicEvaluator::default();
+        let score = eval.evaluate(&self.board);
+        score as f64
+    }
+
+    /// Get the game type string (e.g., "Base+MLP").
+    fn game_type(&self) -> String {
+        self.board.game_type()
+    }
+
+    /// Check if White's queen has been placed.
+    fn white_queen_placed(&self) -> bool {
+        self.board.remaining[0][Bug::Queen as usize] == 0
+    }
+
+    /// Check if Black's queen has been placed.
+    fn black_queen_placed(&self) -> bool {
+        self.board.remaining[1][Bug::Queen as usize] == 0
+    }
+
+    /// Get the number of neighbors surrounding each queen: [black_count, white_count].
+    fn queens_neighbor_count(&self) -> (usize, usize) {
+        let qs = self.board.queens_surrounded();
+        (qs[0], qs[1])
+    }
+}
+
+// Helper functions
+
+fn bug_to_string(bug: Bug) -> String {
+    match bug {
+        Bug::Queen => "queen",
+        Bug::Grasshopper => "grasshopper",
+        Bug::Spider => "spider",
+        Bug::Ant => "ant",
+        Bug::Beetle => "beetle",
+        Bug::Mosquito => "mosquito",
+        Bug::Ladybug => "ladybug",
+        Bug::Pillbug => "pillbug",
+    }.to_string()
+}
+
+fn bug_name_to_index(name: &str) -> u8 {
+    match name {
+        "queen" => 0,
+        "beetle" => 1,
+        "grasshopper" => 2,
+        "ant" => 3,
+        "spider" => 4,
+        "mosquito" => 5,
+        "ladybug" => 6,
+        "pillbug" => 7,
+        _ => 255,
+    }
+}
+
+fn turn_to_pymove(board: &Board, turn: Turn) -> PyMove {
+    match turn {
+        Turn::Place(hex, bug) => {
+            let (q, r) = hex_to_loc(hex);
+            PyMove {
+                turn,
+                move_type: "place".to_string(),
+                piece_type: Some(bug_to_string(bug)),
+                source_q: None,
+                source_r: None,
+                dest_q: Some(q),
+                dest_r: Some(r),
+            }
+        }
+        Turn::Move(src, dst) => {
+            let (sq, sr) = hex_to_loc(src);
+            let (dq, dr) = hex_to_loc(dst);
+            // Get the piece type at the source
+            let node = board.node(src);
+            let piece_type = if node.occupied() {
+                Some(bug_to_string(node.bug()))
+            } else {
+                None
+            };
+            PyMove {
+                turn,
+                move_type: "move".to_string(),
+                piece_type,
+                source_q: Some(sq),
+                source_r: Some(sr),
+                dest_q: Some(dq),
+                dest_r: Some(dr),
+            }
+        }
+        Turn::Pass => PyMove {
+            turn,
+            move_type: "pass".to_string(),
+            piece_type: None,
+            source_q: None,
+            source_r: None,
+            dest_q: None,
+            dest_r: None,
+        },
+    }
+}
+
+/// nokamute Python module
+#[pymodule]
+pub fn nokamute(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<GameState>()?;
+    m.add_class::<PyMove>()?;
+    m.add_class::<PyPiece>()?;
+    Ok(())
+}


### PR DESCRIPTION
Adding some python bindings to support use of nokamute in a deep/reinforcement training loop I'm exploring. Still experimental at this stage so this PR isn't ready to merge. 

Expose GameState, PyMove, and PyPiece classes for use from Python.
Build with `maturin develop --features python`.

- GameState wraps Board with methods for move generation, apply/undo,
  piece inspection, UHP game string parsing, and position evaluation
- PyMove wraps Turn with human-readable fields and canonical sort keys
- PyPiece provides piece info including stacking
- Made necessary board/notation fields and methods pub for binding access

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>