### PR TITLE
Fix threefold repetition not detected for 6-plies cycles

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -869,14 +869,14 @@ impl minimax::Game for Rules {
         if n > 10 {
             // Check for position repeat stalemate.
             // More than 32 turns ago, we're not going to bother looking.
-            // Check every 4 turns as both players need to move and move back to repeat.
+            // Step by 2 since positions only repeat on even half-move boundaries.
             let position_repeat_count = board
                 .zobrist_history
                 .iter()
                 .rev()
-                .step_by(4)
+                .step_by(2)
                 .skip(1)
-                .take(8)
+                .take(16)
                 .filter(|&&hash| hash == board.zobrist_hash)
                 .count();
             if position_repeat_count >= 2 {

--- a/src/board.rs
+++ b/src/board.rs
@@ -1350,4 +1350,13 @@ mod tests {
         let board = Board::from_game_string(r"Base;InProgress;black[11];wA1;bA1 wA1-;wQ /wA1;bQ bA1/;wS1 /wQ;bS1 bQ-;wS2 wQ\;bS2 bS1\;wS1 wS2-;bB1 /bS2;wA2 -wA1;bA2 bA1-;wB1 \wA1;bB1 bA2;wB1 wA2;bB1 bQ;wB1 wQ;bB1 \bB1;wB1 wB1-;bB1 bQ;wB1 wQ").unwrap();
         assert_eq!(None, Rules::get_winner(&board));
     }
+
+    #[test]
+    fn test_winner_sixmove_cycle() {
+        // Regression: 6-move repetition cycles were not detected with step_by(4).
+        let before = Board::from_game_string(r"Base+ML;InProgress;Black[9];wB1;bB1 wB1-;wQ /wB1;bQ bB1\;wA1 -wB1;bQ /bB1;wA1 -wQ;bB1 bQ;wA1 /wQ;bB1 wB1;wA1 -bB1;bB1 bQ/;wA1 -wQ;bB1 bQ;wA1 /wQ;bB1 wB1;wA1 -bB1").unwrap();
+        assert_eq!(None, Rules::get_winner(&before));
+        let after = Board::from_game_string(r"Base+ML;InProgress;White[10];wB1;bB1 wB1-;wQ /wB1;bQ bB1\;wA1 -wB1;bQ /bB1;wA1 -wQ;bB1 bQ;wA1 /wQ;bB1 wB1;wA1 -bB1;bB1 bQ/;wA1 -wQ;bB1 bQ;wA1 /wQ;bB1 wB1;wA1 -bB1;bB1 bQ/").unwrap();
+        assert_eq!(Some(minimax::Winner::Draw), Rules::get_winner(&after));
+    }
 }


### PR DESCRIPTION
The current three-fold repetition does not seem to catch all cases:

> $ ./nokamute 
id nokamute cargo-1.0.3
Mosquito;Ladybug;Pillbug
ok
newgame Base+ML;Draw;White[10];wB1;bB1 wB1-;wQ /wB1;bQ bB1\;wA1 -wB1;bQ /bB1;wA1 -wQ;bB1 bQ;wA1 /wQ;bB1 wB1;wA1 -bB1;bB1 bQ/;wA1 -wQ;bB1 bQ;wA1 /wQ;bB1 wB1;wA1 -bB1;bB1 bQ/
Base+ML;InProgress;White[10];wB1;bB1 wB1-;wQ /wB1;bQ bB1\;wA1 -wB1;bQ wB1\;wA1 /wA1;bB1 bQ;wA1 wA1\;bB1 wB1;wA1 -bB1;bB1 bQ/;wA1 /wA1;bB1 bQ;wA1 wA1\;bB1 wB1;wA1 -bB1;bB1 bQ/
ok

Going back an even number of moves does not suffice as there can also be a repetition after 3 moves, for instance.

That's a one-line fix (and I kept the 32 turn horizon, so two lines).