### PR TITLE
Improve verbose UHP debug diagnostics

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ commands:
         or a path to a UHP engine
  perft [--parallel] [game_state]:
         Count the number of board states at each depth
- uhp-debug [--search=game_state] engine_command
+ uhp-debug [--search=game_state] [--verbose|--uhp-verbose] engine_command
         Run external UHP engine through correctness testsuite,
         then randomly search for discrepancies with nokamute's move generator.
 
@@ -74,6 +74,10 @@ fn main() {
                 args.iter().map(|s| s.into()).collect::<Vec<OsString>>(),
             );
             let search_string: Option<String> = parsed_args.opt_value_from_str("--search").unwrap();
+            // `--verbose` / `-v` is consumed by `configure_player()` as a global engine flag, so
+            // treat that as uhp-debug verbosity too. We also accept `--uhp-verbose` here to avoid
+            // collisions with flags intended for the external engine command.
+            let verbose = config.verbose() || parsed_args.contains("--uhp-verbose");
             let args = parsed_args
                 .finish()
                 .into_iter()
@@ -83,7 +87,7 @@ fn main() {
                 println!("uhp-debug requires engine command");
                 return;
             }
-            let success = uhp_tests(&args[1..]);
+            let success = uhp_tests_with_verbosity(&args[1..], verbose);
             if let Some(string) = search_string {
                 perft_debug(&args[1..], &string, 20);
             }

--- a/src/perft.rs
+++ b/src/perft.rs
@@ -20,6 +20,10 @@ pub fn perft(game_string: &str, parallel: bool) {
 }
 
 pub fn uhp_tests(engine_cmd: &[String]) -> bool {
+    uhp_tests_with_verbosity(engine_cmd, false)
+}
+
+pub fn uhp_tests_with_verbosity(engine_cmd: &[String], verbose: bool) -> bool {
     const FAILED: &str = "\x1b[31mFAILED\x1b[m";
     const PASSED: &str = "\x1b[32mpassed\x1b[m";
     let mut engine = UhpClient::new(engine_cmd).unwrap();
@@ -54,6 +58,9 @@ pub fn uhp_tests(engine_cmd: &[String]) -> bool {
         let game_type = groups.next().unwrap();
         if let Err(error) = engine.new_game(game_type) {
             println!("{FAILED} newgame: {error:?}");
+            if verbose {
+                println!("  testcase: {game_state_string}");
+            }
             success = false;
             continue;
         }
@@ -62,11 +69,22 @@ pub fn uhp_tests(engine_cmd: &[String]) -> bool {
         groups.next();
 
         let mut new_state = "Base;NotStarted".to_string();
+        let mut played_moves = Vec::new();
         for move_string in groups {
             match engine.raw_play(move_string) {
-                Ok(string) => new_state = string,
+                Ok(string) => {
+                    played_moves.push(move_string);
+                    new_state = string;
+                }
                 Err(UhpError::EngineError(error)) => {
                     println!("{FAILED} play {move_string} failed: {error}");
+                    if verbose {
+                        println!("  testcase: {game_state_string}");
+                        if !played_moves.is_empty() {
+                            println!("  played: {}", played_moves.join(";"));
+                            println!("  game log: {}", engine.game_log());
+                        }
+                    }
                     success = false;
                     continue 'testcases;
                 }
@@ -79,6 +97,10 @@ pub fn uhp_tests(engine_cmd: &[String]) -> bool {
         let state = new_state.split(';').nth(1).unwrap_or("not found");
         if expected_state != state {
             println!("{FAILED} end state expected {expected_state} found {state}");
+            if verbose {
+                println!("  testcase: {game_state_string}");
+                println!("  engine state: {new_state}");
+            }
             success = false;
             continue;
         }
@@ -91,16 +113,40 @@ pub fn uhp_tests(engine_cmd: &[String]) -> bool {
             Ok(s) => s,
             Err(error) => {
                 println!("{FAILED} validmoves: {error:?}");
+                if verbose {
+                    println!("  testcase: {game_state_string}");
+                    println!("  game log: {}", engine.game_log());
+                }
                 success = false;
                 continue;
             }
         };
-        // TODO: actually compare moves
-        let expected_count = expected_moves_string.split(';').count();
-        let count = movestrings.split(';').count();
+
+        // TODO: compare moves (not just counts) in non-verbose mode.
+        let expected_moves =
+            expected_moves_string.split(';').filter(|s| !s.trim().is_empty()).collect::<Vec<_>>();
+        let engine_moves =
+            movestrings.split(';').filter(|s| !s.trim().is_empty()).collect::<Vec<_>>();
+
+        let expected_count = expected_moves.len();
+        let count = engine_moves.len();
         if expected_count != count {
-            // TODO: verbose mode: dump difference
             println!("{FAILED} expected {expected_count} moves, found {count}");
+            if verbose {
+                let (missing, extra) = multiset_diff(&expected_moves, &engine_moves);
+                println!("  testcase: {game_state_string}");
+                if let Ok(b) = Board::from_game_string(game_state_string) {
+                    b.println();
+                }
+                if !missing.is_empty() {
+                    println!("  missing moves: {}", missing.join(";"));
+                }
+                if !extra.is_empty() {
+                    println!("  extra moves: {}", extra.join(";"));
+                }
+                println!("  expected moves: {expected_moves_string}");
+                println!("  engine moves: {movestrings}");
+            }
             success = false;
             continue;
         }
@@ -108,6 +154,38 @@ pub fn uhp_tests(engine_cmd: &[String]) -> bool {
         println!("{PASSED}");
     }
     success
+}
+
+fn multiset_diff(expected: &[&str], actual: &[&str]) -> (Vec<String>, Vec<String>) {
+    use std::collections::BTreeMap;
+
+    fn add(map: &mut BTreeMap<String, isize>, key: &str, delta: isize) {
+        let key = key.trim();
+        if key.is_empty() {
+            return;
+        }
+        *map.entry(key.to_string()).or_insert(0) += delta;
+    }
+
+    let mut counts = BTreeMap::<String, isize>::new();
+    for &m in expected {
+        add(&mut counts, m, 1);
+    }
+    for &m in actual {
+        add(&mut counts, m, -1);
+    }
+
+    let mut missing = Vec::new();
+    let mut extra = Vec::new();
+    for (m, delta) in counts {
+        if delta > 0 {
+            missing.push(if delta == 1 { m } else { format!("{m} x{delta}") });
+        } else if delta < 0 {
+            let delta = -delta;
+            extra.push(if delta == 1 { m } else { format!("{m} x{delta}") });
+        }
+    }
+    (missing, extra)
 }
 
 pub fn perft_debug(engine_cmd: &[String], game_string: &str, depth: usize) {
@@ -225,6 +303,11 @@ fn test_perft() {
     b = Board::from_game_type("Base+MLP").unwrap();
     let move_counts = minimax::perft::<Rules>(&mut b, 4, false);
     assert_eq!(move_counts, vec![1, 7, 294, 6678, 151686]);
+}
+
+#[test]
+fn test_uhp_tests_public_signature() {
+    let _: fn(&[String]) -> bool = uhp_tests;
 }
 
 // Regression suite for bugs caught by perft-debug.

--- a/src/perft.rs
+++ b/src/perft.rs
@@ -122,7 +122,6 @@ pub fn uhp_tests_with_verbosity(engine_cmd: &[String], verbose: bool) -> bool {
             }
         };
 
-        // TODO: compare moves (not just counts) in non-verbose mode.
         let expected_moves =
             expected_moves_string.split(';').filter(|s| !s.trim().is_empty()).collect::<Vec<_>>();
         let engine_moves =
@@ -130,19 +129,36 @@ pub fn uhp_tests_with_verbosity(engine_cmd: &[String], verbose: bool) -> bool {
 
         let expected_count = expected_moves.len();
         let count = engine_moves.len();
-        if expected_count != count {
-            println!("{FAILED} expected {expected_count} moves, found {count}");
+        // Different reference pieces can describe the same UHP move, so compare parsed turns.
+        let board = match Board::from_game_string(game_state_string) {
+            Ok(board) => board,
+            Err(error) => {
+                println!("{FAILED} invalid testcase: {error:?}");
+                success = false;
+                continue;
+            }
+        };
+        let difference = semantic_move_diff(&board, &expected_moves, &engine_moves);
+        if !difference.is_empty() {
+            if expected_count != count {
+                println!("{FAILED} expected {expected_count} moves, found {count}");
+            } else {
+                println!("{FAILED} valid moves differ ({count} moves each)");
+            }
             if verbose {
-                let (missing, extra) = multiset_diff(&expected_moves, &engine_moves);
                 println!("  testcase: {game_state_string}");
-                if let Ok(b) = Board::from_game_string(game_state_string) {
-                    b.println();
+                board.println();
+                if !difference.missing.is_empty() {
+                    println!("  missing moves: {}", difference.missing.join(";"));
                 }
-                if !missing.is_empty() {
-                    println!("  missing moves: {}", missing.join(";"));
+                if !difference.extra.is_empty() {
+                    println!("  extra moves: {}", difference.extra.join(";"));
                 }
-                if !extra.is_empty() {
-                    println!("  extra moves: {}", extra.join(";"));
+                if !difference.invalid_expected.is_empty() {
+                    println!("  invalid expected moves: {}", difference.invalid_expected.join(";"));
+                }
+                if !difference.invalid_actual.is_empty() {
+                    println!("  invalid engine moves: {}", difference.invalid_actual.join(";"));
                 }
                 println!("  expected moves: {expected_moves_string}");
                 println!("  engine moves: {movestrings}");
@@ -156,36 +172,73 @@ pub fn uhp_tests_with_verbosity(engine_cmd: &[String], verbose: bool) -> bool {
     success
 }
 
-fn multiset_diff(expected: &[&str], actual: &[&str]) -> (Vec<String>, Vec<String>) {
+#[derive(Debug, Default, Eq, PartialEq)]
+struct MoveDifference<'a> {
+    missing: Vec<&'a str>,
+    extra: Vec<&'a str>,
+    invalid_expected: Vec<&'a str>,
+    invalid_actual: Vec<&'a str>,
+}
+
+impl MoveDifference<'_> {
+    fn is_empty(&self) -> bool {
+        self.missing.is_empty()
+            && self.extra.is_empty()
+            && self.invalid_expected.is_empty()
+            && self.invalid_actual.is_empty()
+    }
+}
+
+fn semantic_move_diff<'a>(
+    board: &Board, expected: &[&'a str], actual: &[&'a str],
+) -> MoveDifference<'a> {
     use std::collections::BTreeMap;
 
-    fn add(map: &mut BTreeMap<String, isize>, key: &str, delta: isize) {
-        let key = key.trim();
-        if key.is_empty() {
-            return;
+    fn group_moves<'a>(
+        board: &Board, moves: &[&'a str],
+    ) -> (BTreeMap<Turn, Vec<&'a str>>, Vec<&'a str>) {
+        let mut grouped = BTreeMap::<Turn, Vec<&str>>::new();
+        let mut invalid = Vec::new();
+        for &move_string in moves {
+            match parse_comparable_move(board, move_string) {
+                Ok(turn) => grouped.entry(turn).or_default().push(move_string),
+                Err(_) => invalid.push(move_string),
+            }
         }
-        *map.entry(key.to_string()).or_insert(0) += delta;
+        (grouped, invalid)
     }
 
-    let mut counts = BTreeMap::<String, isize>::new();
-    for &m in expected {
-        add(&mut counts, m, 1);
+    // Keep each original string so diagnostics reproduce the exact notation after matching turns.
+    let (expected_by_turn, invalid_expected) = group_moves(board, expected);
+    let (mut actual_by_turn, invalid_actual) = group_moves(board, actual);
+    let mut difference = MoveDifference { invalid_expected, invalid_actual, ..Default::default() };
+
+    for (turn, expected_strings) in expected_by_turn {
+        let actual_strings = actual_by_turn.remove(&turn).unwrap_or_default();
+        let matched = expected_strings.len().min(actual_strings.len());
+        difference.missing.extend_from_slice(&expected_strings[matched..]);
+        difference.extra.extend_from_slice(&actual_strings[matched..]);
     }
-    for &m in actual {
-        add(&mut counts, m, -1);
+    for actual_strings in actual_by_turn.into_values() {
+        difference.extra.extend(actual_strings);
     }
 
-    let mut missing = Vec::new();
-    let mut extra = Vec::new();
-    for (m, delta) in counts {
-        if delta > 0 {
-            missing.push(if delta == 1 { m } else { format!("{m} x{delta}") });
-        } else if delta < 0 {
-            let delta = -delta;
-            extra.push(if delta == 1 { m } else { format!("{m} x{delta}") });
+    difference
+}
+
+fn parse_comparable_move(board: &Board, move_string: &str) -> Result<Turn, UhpError> {
+    let move_string = move_string.trim();
+    let turn = board.from_move_string(move_string)?;
+    if let Turn::Move(_, _) = turn {
+        let source = move_string.split_once(' ').map(|(source, _)| source);
+        let canonical = board.to_move_string(turn);
+        let canonical_source = canonical.split_once(' ').map(|(source, _)| source);
+        // Pillbug throws may move an opponent's piece, but the named source must still be on top.
+        if source != canonical_source {
+            return Err(UhpError::InvalidMove(move_string.to_owned()));
         }
     }
-    (missing, extra)
+    Ok(turn)
 }
 
 pub fn perft_debug(engine_cmd: &[String], game_string: &str, depth: usize) {
@@ -308,6 +361,52 @@ fn test_perft() {
 #[test]
 fn test_uhp_tests_public_signature() {
     let _: fn(&[String]) -> bool = uhp_tests;
+}
+
+#[test]
+fn test_semantic_move_diff_accepts_equivalent_references() {
+    let board =
+        Board::from_game_string("Base;InProgress;White[3];wG1;bG1 wG1-;wQ -wG1;bQ bG1-").unwrap();
+    let difference = semantic_move_diff(&board, &[r"wA1 \wG1"], &["wA1 wQ/"]);
+    assert!(difference.is_empty(), "{difference:?}");
+}
+
+#[test]
+fn test_semantic_move_diff_finds_equal_count_mismatch() {
+    let board =
+        Board::from_game_string("Base;InProgress;White[3];wG1;bG1 wG1-;wQ -wG1;bQ bG1-").unwrap();
+    let difference = semantic_move_diff(&board, &[r"wA1 \wG1"], &["wA1 -wQ"]);
+    assert_eq!(difference.missing, vec![r"wA1 \wG1"]);
+    assert_eq!(difference.extra, vec!["wA1 -wQ"]);
+}
+
+#[test]
+fn test_semantic_move_diff_finds_duplicates_and_invalid_moves() {
+    let board =
+        Board::from_game_string("Base;InProgress;White[3];wG1;bG1 wG1-;wQ -wG1;bQ bG1-").unwrap();
+    let difference = semantic_move_diff(
+        &board,
+        &[r"wA1 \wG1", "invalid-fixture-move"],
+        &[r"wA1 \wG1", "wA1 wQ/", "invalid-engine-move"],
+    );
+    assert_eq!(difference.extra, vec!["wA1 wQ/"]);
+    assert_eq!(difference.invalid_expected, vec!["invalid-fixture-move"]);
+    assert_eq!(difference.invalid_actual, vec!["invalid-engine-move"]);
+}
+
+#[test]
+fn test_semantic_move_diff_rejects_covered_sources() {
+    let board = Board::from_game_string(
+        r"Base;InProgress;White[10];wG1;bG1 wG1-;wQ /wG1;bQ bG1-;wS1 wQ\;bA1 bQ-;wB1 /wS1;bA1 -wQ;wB1 wS1\;bA2 bQ-;wB1 /wS1;bA2 wG1\;wB1 wS1\;bA3 bQ-;wB1 /wS1;bS1 bQ\;wB1 wS1;bS1 wB1\",
+    )
+    .unwrap();
+    let legal = "wB1 /wB1";
+    let covered = "wS1 /wB1";
+    assert_eq!(board.from_move_string(legal).unwrap(), board.from_move_string(covered).unwrap());
+
+    let difference = semantic_move_diff(&board, &[legal], &[covered]);
+    assert_eq!(difference.missing, vec![legal]);
+    assert_eq!(difference.invalid_actual, vec![covered]);
 }
 
 // Regression suite for bugs caught by perft-debug.

--- a/src/player.rs
+++ b/src/player.rs
@@ -297,6 +297,10 @@ impl PlayerConfig {
         }
     }
 
+    pub fn verbose(&self) -> bool {
+        self.opts.verbose
+    }
+
     #[cfg(target_arch = "wasm32")]
     pub(crate) fn new_player(&self) -> Box<dyn Player + Send> {
         Box::new(NokamutePlayer::new(


### PR DESCRIPTION
## Summary

  - Add `--verbose` and `--uhp-verbose` diagnostics to `uhp-debug`.
  - Show failing test cases, board state, game log, and missing/extra moves.
  - Compare moves semantically as parsed `Turn` values, allowing equivalent UHP reference-piece notation.
  - Detect equal-count mismatches, duplicates, invalid moves, and covered-piece source names.
  - Preserve the existing public `uhp_tests(&cmd)` API.

  ## Example output

  A test engine returned the correct move count but duplicated one move:

  ```text
  Test Queen moves... FAILED valid moves differ (2 moves each)
    testcase: Base;InProgress;White[12];...
    missing moves: wQ \bG1
    extra moves: wQ /wQ
    expected moves: wQ \bG1;wQ -wG1
    engine moves: wQ /wQ;wQ /wQ
```

  ## Testing

  - cargo test
  - cargo test --features=smaller-grid
  - Self-hosted uhp-debug suite against Nokamute